### PR TITLE
Task 9 - Removed STATICFILES_DIRS in production

### DIFF
--- a/event_management/settings.py
+++ b/event_management/settings.py
@@ -43,7 +43,13 @@ IS_VERCEL = os.environ.get('VERCEL', False)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / 'staticfiles'  # Where collectstatic puts files
-STATICFILES_DIRS = [BASE_DIR / 'static']  # Your static files directory
+
+# Only use STATICFILES_DIRS in development
+if DEBUG and not IS_VERCEL:
+    STATICFILES_DIRS = [BASE_DIR / 'static']
+else:
+    # Don't use STATICFILES_DIRS in production after collectstatic
+    STATICFILES_DIRS = []
 
 # ALLOWED_HOSTS configuration
 if IS_VERCEL:


### PR DESCRIPTION
This pull request updates the static files configuration in `event_management/settings.py` to better handle development and production environments. The main change is to ensure that `STATICFILES_DIRS` is only set during development, preventing issues in production deployments.

**Environment-specific static files handling:**

* Only set `STATICFILES_DIRS` to include the local `static` directory when running in development mode (`DEBUG` and not `IS_VERCEL`); in production, set it to an empty list to avoid conflicts after running `collectstatic`.